### PR TITLE
Change bower name of the package

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "leaflet",
+  "name": "leaflet-dist",
   "version": "0.7.2",
   "main": ["leaflet-src.js", "leaflet.css"],
   "description": "Leaflet Bower package",


### PR DESCRIPTION
Hello.

My builder is broken due to incorrect name bower component. Please accept the changes that I could use [leaflet.draw](https://github.com/Leaflet/Leaflet.draw)
